### PR TITLE
RD-4503: Handle missing username in Gitlab sessionstate

### DIFF
--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -71,7 +71,6 @@ func (s *SessionState) EncryptedString(c *cookie.Cipher) (string, error) {
 
 func decodeSessionStatePlain(v string) (s *SessionState, err error) {
 	chunks := strings.Split(v, " ")
-	email := strings.TrimPrefix(chunks[0], "email:")
 	user := ""
 	if len(chunks) == 1 {
 		// for Admin users, Gitlab 10 only returns the email
@@ -81,6 +80,7 @@ func decodeSessionStatePlain(v string) (s *SessionState, err error) {
 		return nil, fmt.Errorf("could not decode session state: expected 1-2 chunks got %d", len(chunks))
 	}
 
+	email := strings.TrimPrefix(chunks[0], "email:")
 	if user == "" {
 		user = strings.Split(email, "@")[0]
 	}

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -71,14 +71,16 @@ func (s *SessionState) EncryptedString(c *cookie.Cipher) (string, error) {
 
 func decodeSessionStatePlain(v string) (s *SessionState, err error) {
 	chunks := strings.Split(v, " ")
-
-	email := strings.TrimPrefix(chunks[0], "email:")
-	user := ""
-	// for Admin users, Gitlab 10 only returns the email
-	if len(chunks) > 1 {
-		user = strings.TrimPrefix(chunks[1], "user:")
+	if len(chunks) == 1 {
+		// for Admin users, Gitlab 10 only returns the email
+		user := ""
+	} else if len(chunks) == 2 {
+		user := strings.TrimPrefix(chunks[1], "user:")
+	} else {
+		return nil, fmt.Errorf("could not decode session state: expected 1-2 chunks got %d", len(chunks))
 	}
 
+	email := strings.TrimPrefix(chunks[0], "email:")
 	if user == "" {
 		user = strings.Split(email, "@")[0]
 	}

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -71,16 +71,16 @@ func (s *SessionState) EncryptedString(c *cookie.Cipher) (string, error) {
 
 func decodeSessionStatePlain(v string) (s *SessionState, err error) {
 	chunks := strings.Split(v, " ")
+	email := strings.TrimPrefix(chunks[0], "email:")
+	user := ""
 	if len(chunks) == 1 {
 		// for Admin users, Gitlab 10 only returns the email
-		user := ""
 	} else if len(chunks) == 2 {
-		user := strings.TrimPrefix(chunks[1], "user:")
+		user = strings.TrimPrefix(chunks[1], "user:")
 	} else {
 		return nil, fmt.Errorf("could not decode session state: expected 1-2 chunks got %d", len(chunks))
 	}
 
-	email := strings.TrimPrefix(chunks[0], "email:")
 	if user == "" {
 		user = strings.Split(email, "@")[0]
 	}

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -71,12 +71,14 @@ func (s *SessionState) EncryptedString(c *cookie.Cipher) (string, error) {
 
 func decodeSessionStatePlain(v string) (s *SessionState, err error) {
 	chunks := strings.Split(v, " ")
-	if len(chunks) != 2 {
-		return nil, fmt.Errorf("could not decode session state: expected 2 chunks got %d", len(chunks))
-	}
 
 	email := strings.TrimPrefix(chunks[0], "email:")
-	user := strings.TrimPrefix(chunks[1], "user:")
+	user := ""
+	// for Admin users, Gitlab 10 only returns the email
+	if len(chunks) > 1 {
+		user = strings.TrimPrefix(chunks[1], "user:")
+	}
+
 	if user == "" {
 		user = strings.Split(email, "@")[0]
 	}


### PR DESCRIPTION
For normal users, Gitlab has an email and username field in the session info.  Admin users only have email.